### PR TITLE
Quick and dirty fix for feed link on archive by month.

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -139,10 +139,12 @@ function analog_get_feeds_link() {
 	elseif( is_post_type_archive() ) {
 		$link = get_post_type_archive_feed_link( $item->name );
 	}
+	elseif( is_month() || is_year() || is_day() ) {
+		$link = "/feed"; // pretty rough, but no error at least
+	}
 	
 	return $link;
 }
-
 
 /**
  * Remove prefix from archive title


### PR DESCRIPTION
I've noticed there's an error when I display archive for elected month.

I'm new to te Wordpress development, so I didn't find an easy and clean way to fix this, hence this hack. 
Actually news feeds don't make much sense in this context anyway, so maybe it would be better to remove the whole link anyway.